### PR TITLE
Clarify instructions for Mac OS X Sequoia, and requirement to have arc in iii mode to use diii.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,21 @@ pip3 install monome-diii
 diii
 ```
 
+If you have issues with permissions on Mac OS X Sequoia, try:
+
+```bash
+pipx install monome-diii
+```
+
+
 ## diii
 
-Start by running `diii`
+Start by running `diii` 
+
+Note: arc needs to be in iii mode when plugged into computer for diii to connect.
 
 - type q (enter) to quit.
 - type h (enter) for a list of special commands.
-
 - will reconnect to device after a disconnect / restart
 - scrollable console history
 


### PR DESCRIPTION
Loving my new arc! A couple of things took me a bit to figure out, so thought it might be useful for instructions  to clarify helpfulness of using pipx virtual environment so that diii will work in Mac OS X Sequoia, and also that the Arc needs to be in iii mode when plugged into computer for diii to connect.